### PR TITLE
clean up Swagger docs

### DIFF
--- a/src/main/java/com/dhyer/light_bikes/GamesController.java
+++ b/src/main/java/com/dhyer/light_bikes/GamesController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.UUID;
 
@@ -176,6 +177,7 @@ public class GamesController {
     return dynamicFlux;
   }
 
+  @ApiIgnore
   @DeleteMapping
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void clearGames(

--- a/src/main/java/com/dhyer/light_bikes/SwaggerConfig.java
+++ b/src/main/java/com/dhyer/light_bikes/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.dhyer.light_bikes;
 
+import com.google.common.base.Predicates;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
@@ -16,7 +17,7 @@ public class SwaggerConfig {
     return new Docket(DocumentationType.SWAGGER_2)
         .select()
         .apis(RequestHandlerSelectors.any())
-        .paths(PathSelectors.any())
+        .paths(Predicates.not(PathSelectors.regex("/(error|health-check).*")))
         .build();
   }
 }


### PR DESCRIPTION
Hide endpoints that aren't needed for end users from the Swagger docs